### PR TITLE
Add an optional short description for reports

### DIFF
--- a/FrxEditor.inc
+++ b/FrxEditor.inc
@@ -447,6 +447,49 @@ class FrxEditor {
   }
 
   /**
+   * Set the report description
+   * @param string $description
+   */
+  public function setDescription($description) {
+    $ret = array();
+    $dom = $this->dom;
+    $head = $dom->getElementsByTagName('head')->item(0);
+    $cnodes = $dom->getElementsByTagName('meta');
+    $node = $dom->createElement('meta');
+    $node->setAttribute('content', htmlspecialchars($description));
+    $node->setAttribute('name', 'description');
+    $cnode = NULL;
+    foreach ($cnodes as $cnode) {
+      if ($cnode->getAttribute('name') == 'description') {
+        break;
+      }
+    }
+    if (is_object($cnode)) {
+      $head->replaceChild($node, $cnode);
+    } else {
+      $head->appendChild($node);
+    }
+  }
+
+  /**
+   * Get the report description
+   * @return string 
+   */
+  public function getDescription() {
+    $dom = $this->dom;
+    $this->verifyHeaderElements(array('description'));
+    $cnodes = $dom->getElementsByTagName('meta');
+    $cnode = NULL;
+    foreach ($cnodes as $cnode) {
+      if ($cnode->getAttribute('name') == 'description') {
+        break;
+      }
+    }
+    $textContent = is_object($cnode) ? $cnode->getAttribute('content') : '';
+    return htmlspecialchars_decode($textContent);
+  }
+
+  /**
    * Set the report category
    * Enter description here ...
    * @param unknown_type $cateogry

--- a/FrxReport.inc
+++ b/FrxReport.inc
@@ -15,6 +15,7 @@ class FrxReport {
   public $rpt_xml;
   public $fields;
   public $category;
+  public $description;
   public $cache;
   public $descriptor;
   public $form;
@@ -121,6 +122,13 @@ class FrxReport {
         $arr = $value->attributes();
         $this->formats[] = (string)$arr['type'];
       }
+      $nodes = $rpt_xml->xpath('//head/meta[@name="description"]');
+      $arr = array('content' => '');
+      if ($nodes) foreach ($nodes as $node) {
+        $arr = $node->attributes();
+        break;
+      }
+      $this->description = (string)$arr['content'];
 
 
       foreach ($rpt_xml->head->children(FRX_NS) as $name => $node) {
@@ -736,6 +744,13 @@ class FrxReport {
   public function parametersForm($variables = array()) {
     $parms = $this->parametersArray();
     $form =  drupal_get_form('forena_parameter_form', $parms, $variables);
+    // prefix the form with the report description, if applicable
+    if ($this->description && isset($form['params']) && is_array($form['params'])) {
+      $form['params'] = array('forena-report-description' => array(
+        '#type' => 'item',
+        '#markup' => htmlspecialchars($this->description),
+      )) + $form['params'];
+    }
     $this->parameters_form = $form;
     return $form;
   }

--- a/FrxReportFile.inc
+++ b/FrxReportFile.inc
@@ -155,6 +155,7 @@ class FrxReportFile extends FrxFile {
                 'title' => $cache['title'],
                 'category' => $cache['category'],
                 'report_name' => $base_name,
+                'description' => $cache['description'],
             );
           }
 
@@ -219,6 +220,7 @@ class FrxReportFile extends FrxFile {
           $cache['language'] = $lang;
           $cache['category'] = $r->category;
           $cache['hidden'] = @$r->options['hidden'];
+          $cache['description'] = $r->description;
         }
         $object->cache = $cache;
     	  if ($r) $r->__destruct();

--- a/default.frx
+++ b/default.frx
@@ -5,6 +5,7 @@
 <html xmlns:frx="urn:FrxReports">
 <head>
 <title></title>
+<meta type="description" content="" />
 <frx:category></frx:category>
 <frx:options></frx:options>
 <frx:parameters>

--- a/forena.module
+++ b/forena.module
@@ -983,11 +983,11 @@ function forena_user_reports($category = '') {
   foreach ($reports as $category => $reports) {
     $links .= '<li><a href="#' . urlencode($category) . '">' . $category . '</a></li> ';
     $output .= '<h3 id="' . urlencode($category) . '">' . $category . '</h3>';
-    $output .= '<ul>';
+    $output .= '<ul>'."\n";
     foreach ($reports as $r) {
-      $output .= '<li>' . l($r['title'], $report_repos . '/' . str_replace('/', '.', $r['report_name'])) . '</li>';
+      $output .= '<li>' . l($r['title'], $report_repos . '/' . str_replace('/', '.', $r['report_name'])) . '<div class="forena-report-description">' . $r['description'] . '</div></li>'."\n";
     }
-    $output .= '</ul>';
+    $output .= '</ul>'."\n";
   }
   return $output;
 }

--- a/forena.report.inc
+++ b/forena.report.inc
@@ -62,6 +62,11 @@ function forena_add_report_form($formid, $form_state, $report_name='') {
       '#machine_name' => array('source' => array('report_name'), 'label' => 'Report_name'),
   );
 
+  $form['description'] = array(
+      '#type' => 'textarea',
+      '#title' => t('Description'),
+      '#description' => t('A description of the report, visible in the report list and in the parameters form.'),
+  );
 
   $form['category'] = array(
       '#type' => 'textfield',
@@ -126,6 +131,7 @@ function forena_create_report_submit($form, &$form_state) {
   // Title and category
   $r->setTitle($values['title']);
   $r->setCategory($values['category']);
+  $r->setDescription($values['description']);
   // Form options
   $options = array(
       'hidden' => $values['hidden'],
@@ -1507,6 +1513,8 @@ function forena_report_layout_form($form, &$form_state, $report_name) {
   $filter = variable_get('forena_input_format', 'none');
   if (isset($frx_options['input_format'])) $filter = $frx_options['input_format'];
 
+  $description = $r->getDescription();
+
   $body = $r->simplexml->body->asXML();
   $css = @(string)$r->simplexml->head->style;
 
@@ -1532,6 +1540,11 @@ function forena_report_layout_form($form, &$form_state, $report_name) {
       '#description' => t('The page style of your report.  The {skin}.skinfo file specifies css and js file in your report.')
   );
 
+  $form['description'] = array(
+      '#type' => 'textarea',
+      '#title' => t('Description'),
+      '#default_value' => $description,
+  );
 
   $form['body'] = array(
       '#type' => 'text_format',
@@ -1609,6 +1622,8 @@ function forena_report_layout_form_submit($form, &$form_state) {
   $options['skin'] = $values['skin'];
   $r->setOptions($options);
 
+  // Description
+  $r->setDescription($values['description']);
   // Body
   $r->setBody($values['body']['value']);
   // CSS


### PR DESCRIPTION
Short description for reports will be stored in the HTML `meta[@name='description']` element.  It will be displayed in the list of user reports and in the parameters form (if applicable).