### PR TITLE
change cancel tag to link from button.fix issue #SYSDEV-349

### DIFF
--- a/forena.report.inc
+++ b/forena.report.inc
@@ -1420,9 +1420,9 @@ function forena_report_add_parameter_form($form, &$form_state, $report_name) {
   );
 
   $form['cancel'] = array(
-      '#type' => 'submit',
-      '#value' => t('Cancel'),
-      '#submit' => array('forena_update_cancel'),
+       '#type' => 'link',
+       '#href' => "reports/$report_name/edit",
+       '#title' => 'Cancel'
   );
 
   return $form;

--- a/forena.report.inc
+++ b/forena.report.inc
@@ -1420,9 +1420,9 @@ function forena_report_add_parameter_form($form, &$form_state, $report_name) {
   );
 
   $form['cancel'] = array(
-       '#type' => 'link',
-       '#href' => "reports/$report_name/edit",
-       '#title' => 'Cancel'
+       '#type'  => 'link',
+       '#href'  => "reports/$report_name/edit",
+       '#title' => t('Cancel')
   );
 
   return $form;


### PR DESCRIPTION
Following changes are made - 
1. Cancel button is replaced by link attribute.
2. If a field is set as "required", then Drupal validates the field whenever the user tries to submit a form. As cancel button was of type submit, id field was validated everytime it was clicked.